### PR TITLE
ModuleManagerController: Remove component ServerAddressList

### DIFF
--- a/server-libs/modman-base/lib/CMakeLists.txt
+++ b/server-libs/modman-base/lib/CMakeLists.txt
@@ -14,7 +14,6 @@ add_library(ModmanBase SHARED
 target_link_libraries(ModmanBase 
     PUBLIC
     Qt5::Core
-    Qt5::Network
     VfHelpers
     VfEvent
     VfComponent

--- a/server-libs/modman-base/lib/modulemanagercontroller.cpp
+++ b/server-libs/modman-base/lib/modulemanagercontroller.cpp
@@ -7,9 +7,6 @@
 #include <vcmp_entitydata.h>
 #include <vcmp_introspectiondata.h>
 
-#include <QNetworkInterface>
-#include <QHostAddress>
-
 #include <QJsonArray>
 #include <QDateTime>
 
@@ -22,7 +19,6 @@ constexpr QLatin1String ModuleManagerController::s_sessionsAvailableComponentNam
 constexpr QLatin1String ModuleManagerController::s_notificationMessagesComponentName;
 constexpr QLatin1String ModuleManagerController::s_loggedComponentsComponentName;
 constexpr QLatin1String ModuleManagerController::s_modulesPausedComponentName;
-constexpr QLatin1String ModuleManagerController::s_serverIpComponentName;
 
 ModuleManagerController::ModuleManagerController(QObject *t_parent) :
     VeinEvent::EventSystem(t_parent)
@@ -194,12 +190,6 @@ void ModuleManagerController::initOnce()
 
         emit sigSendEvent(new VeinEvent::CommandEvent(VeinEvent::CommandEvent::EventSubtype::NOTIFICATION, systemData));
 
-        QVariantList ipAdressList;
-        for (const QHostAddress &address : QNetworkInterface::allAddresses()) {
-            if (address != QHostAddress(QHostAddress::LocalHost) && address != QHostAddress(QHostAddress::LocalHostIPv6))
-                ipAdressList.append(address.toString());
-        }
-
         QHash<QString, QVariant> componentData;
         componentData.insert(ModuleManagerController::s_entityNameComponentName, ModuleManagerController::s_entityName);
         componentData.insert(ModuleManagerController::s_entitiesComponentName, QVariant());
@@ -208,7 +198,6 @@ void ModuleManagerController::initOnce()
         componentData.insert(ModuleManagerController::s_notificationMessagesComponentName, QVariant(m_notificationMessages.toJson()));
         componentData.insert(ModuleManagerController::s_loggedComponentsComponentName, QVariantMap());
         componentData.insert(ModuleManagerController::s_modulesPausedComponentName, QVariant(false));
-        componentData.insert(ModuleManagerController::s_serverIpComponentName, ipAdressList);
 
         VeinComponent::ComponentData *initialData=nullptr;
         for(const QString &compName : componentData.keys())

--- a/server-libs/modman-base/lib/modulemanagercontroller.h
+++ b/server-libs/modman-base/lib/modulemanagercontroller.h
@@ -75,7 +75,6 @@ private:
     static constexpr QLatin1String s_sessionsAvailableComponentName = modman_util::to_latin1("SessionsAvailable");
     static constexpr QLatin1String s_loggedComponentsComponentName = modman_util::to_latin1("LoggedComponents");
     static constexpr QLatin1String s_modulesPausedComponentName = modman_util::to_latin1("ModulesPaused");
-    static constexpr QLatin1String s_serverIpComponentName = modman_util::to_latin1("ServerAddressList");
 
 
     VeinEvent::StorageSystem *m_storageSystem = nullptr;

--- a/server-libs/modman-base/tests/test_modman_start.cpp
+++ b/server-libs/modman-base/tests/test_modman_start.cpp
@@ -36,9 +36,8 @@ void test_modman_start::emptyModman()
     VfTestComponentAddListener::AddHash hash = vfListener.getComponentHash();
     QCOMPARE(hash.size(), 1);
     int entityId = 0;
-    QCOMPARE(hash[entityId].size(), 8);
+    QCOMPARE(hash[entityId].size(), 7);
     QCOMPARE(hash[entityId]["EntityName"], "_System");
-    QCOMPARE(hash[entityId].contains("ServerAddressList"), true);
     QCOMPARE(hash[entityId].contains("Session"), true);
     QCOMPARE(hash[entityId].contains("SessionsAvailable"), true);
     QCOMPARE(hash[entityId]["Entities"], QVariant());


### PR DESCRIPTION
It is not used anymore because of:

* It does not track changes e.g connection to Wifi during runtime
* GUIs networkmanager implementation does the job
* It buyd us Qt::Network dependency which came up as a bit of surprise