### PR TITLE
Revert "CMake: Increase min version"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.1)
 
 project(vein-framework
     LANGUAGES CXX


### PR DESCRIPTION
It caused unforseeable results in zera-classes

This reverts commit c0d8d807a5c79248742cd93e276fbef68b73fae9.