### PR TITLE
vf-tcp/xiqnet: When not connected: Do not assert but warn and bail out

### DIFF
--- a/network/vf-tcp/lib/vtcp_peerworker.cpp
+++ b/network/vf-tcp/lib/vtcp_peerworker.cpp
@@ -80,9 +80,10 @@ QByteArray TcpPeerWorker::readArray() const
 
 void TcpPeerWorker::sendArray(const QByteArray &byteArray) const
 {
-    Q_ASSERT_X(isConnected(), __PRETTY_FUNCTION__, "[vein-tcp] Trying to send data to disconnected host.");
-    Q_ASSERT(m_tcpSock != nullptr && m_tcpSock->isOpen());
-
+    if(!isConnected() || !m_tcpSock || !m_tcpSock->isOpen()) {
+        qWarning("[vein-tcp] Trying to send data to disconnected host.");
+        return;
+    }
     QDataStream out(m_tcpSock);
     out.setVersion(QDataStream::Qt_5_7);
     out << byteArray;

--- a/network/xiqnet/xiqnetpeer.cpp
+++ b/network/xiqnet/xiqnetpeer.cpp
@@ -83,9 +83,10 @@ void XiQNetPeer::setWrapper(XiQNetWrapper *value)
 
 void XiQNetPeer::sendMessage(const google::protobuf::Message &t_message) const
 {
-    Q_ASSERT_X(isConnected(), __PRETTY_FUNCTION__, "[xiqnet-qt] Trying to send data to disconnected host.");
-    Q_ASSERT(d_ptr->m_wrapper != nullptr);
-
+    if(!isConnected() || !d_ptr->m_wrapper) {
+        qWarning("[xiqnet-qt] Trying to send data to disconnected host.");
+        return;
+    }
     d_ptr->sendArray(d_ptr->m_wrapper->protobufToByteArray(t_message));
 }
 


### PR DESCRIPTION
* We need a more polite behavior for tests and debugging
* Once this happens, things have gone downhill badly already...