### PR TITLE
vs_veinhash: Spawn a warning on component type change

### DIFF
--- a/framework/vf-storage-hash/vs_veinhash.cpp
+++ b/framework/vf-storage-hash/vs_veinhash.cpp
@@ -86,8 +86,13 @@ void VeinHash::processComponentData(QEvent *event)
             ErrorDataSender::errorOut(QString("Cannot set component for not existing entity id: %1").arg(entityId), event, this);
         else if(!component)
             ErrorDataSender::errorOut(QString("Cannot set not existing component: %1 %2").arg(entityId).arg(cData->componentName()), event, this);
-        else
+        else {
+            if(component->getValue().isValid() && component->getValue().type() != cData->newValue().type())
+                qWarning("QVariant type change detected on entity %i / component %s: Old %s / new %s",
+                         entityId, qPrintable(componentName),
+                         qPrintable(component->getValue().typeName()), qPrintable(cData->newValue().typeName()));
             m_privHash->changeComponentValue(component, cData->newValue());
+        }
         break;
     case ComponentData::Command::CCMD_FETCH:
         if(!entity)


### PR DESCRIPTION
We learned that changing type can cause serious issues: GUI expects certain types and freaks out if that does not match.

* For now: Just let debug (developers) see warnings e.g: how do we test this on SCPI???
* After fixing we should make this an error