### PR TITLE
SystemModuleEventSystem: Remove component LoggedComponents - it will …

### DIFF
--- a/convenient-code/lib/commands/vf_server_component_setter.cpp
+++ b/convenient-code/lib/commands/vf_server_component_setter.cpp
@@ -1,0 +1,19 @@
+#include "vf_server_component_setter.h"
+#include "ve_commandevent.h"
+#include <vcmp_componentdata.h>
+
+using namespace VeinEvent;
+using namespace VeinComponent;
+
+QEvent *VfServerComponentSetter::generateEvent(int entityId, QString componentName, QVariant oldValue, QVariant newValue)
+{
+    ComponentData *cData = new ComponentData(entityId, ComponentData::Command::CCMD_SET);
+    cData->setEventOrigin(ComponentData::EventOrigin::EO_LOCAL);
+    cData->setEventTarget(ComponentData::EventTarget::ET_ALL);
+    cData->setComponentName(componentName);
+
+    cData->setNewValue(newValue);
+    cData->setOldValue(oldValue);
+
+    return new CommandEvent(CommandEvent::EventSubtype::NOTIFICATION, cData);
+}

--- a/convenient-code/lib/commands/vf_server_component_setter.h
+++ b/convenient-code/lib/commands/vf_server_component_setter.h
@@ -1,0 +1,13 @@
+#ifndef VFSERVERCOMPONENTSETTER_H
+#define VFSERVERCOMPONENTSETTER_H
+
+#include <QEvent>
+#include <QVariant>
+
+class VfServerComponentSetter
+{
+public:
+    static QEvent *generateEvent(int entityId, QString componentName, QVariant oldValue, QVariant newValue);
+};
+
+#endif // VFSERVERCOMPONENTSETTER_H

--- a/convenient-code/tests/test_client_entity_subscriber.cpp
+++ b/convenient-code/tests/test_client_entity_subscriber.cpp
@@ -158,7 +158,6 @@ void test_client_entity_subscriber::introspectComponentNames()
     QVERIFY(componentNames.contains("Entities"));
     QVERIFY(componentNames.contains("ModulesPaused"));
     QVERIFY(componentNames.contains("Error_Messages"));
-    QVERIFY(componentNames.contains("LoggedComponents"));
     QVERIFY(componentNames.contains("DevMode"));
 }
 

--- a/framework/tests/test-data/dumpEventsSubscribe.json
+++ b/framework/tests/test-data/dumpEventsSubscribe.json
@@ -58,7 +58,6 @@
                     "Entities",
                     "EntityName",
                     "Error_Messages",
-                    "LoggedComponents",
                     "ModulesPaused",
                     "Session",
                     "SessionsAvailable"
@@ -82,7 +81,6 @@
                     "Entities",
                     "EntityName",
                     "Error_Messages",
-                    "LoggedComponents",
                     "ModulesPaused",
                     "Session",
                     "SessionsAvailable"
@@ -106,7 +104,6 @@
                     "Entities",
                     "EntityName",
                     "Error_Messages",
-                    "LoggedComponents",
                     "ModulesPaused",
                     "Session",
                     "SessionsAvailable"
@@ -130,7 +127,6 @@
                     "Entities",
                     "EntityName",
                     "Error_Messages",
-                    "LoggedComponents",
                     "ModulesPaused",
                     "Session",
                     "SessionsAvailable"

--- a/framework/tests/test-data/dumpStorageComponentAddRemove.json
+++ b/framework/tests/test-data/dumpStorageComponentAddRemove.json
@@ -4,8 +4,6 @@
         "Entities": null,
         "EntityName": "_System",
         "Error_Messages": null,
-        "LoggedComponents": {
-        },
         "ModulesPaused": false,
         "Session": "",
         "SessionsAvailable": [

--- a/framework/tests/test-data/dumpStorageComponentSet.json
+++ b/framework/tests/test-data/dumpStorageComponentSet.json
@@ -4,8 +4,6 @@
         "Entities": null,
         "EntityName": "_System",
         "Error_Messages": null,
-        "LoggedComponents": {
-        },
         "ModulesPaused": false,
         "Session": "",
         "SessionsAvailable": [

--- a/framework/tests/test-data/dumpStorageEntityAddRemove.json
+++ b/framework/tests/test-data/dumpStorageEntityAddRemove.json
@@ -4,8 +4,6 @@
         "Entities": null,
         "EntityName": "_System",
         "Error_Messages": null,
-        "LoggedComponents": {
-        },
         "ModulesPaused": false,
         "Session": "",
         "SessionsAvailable": [

--- a/framework/tests/test-data/dumpStorageEntityAdded.json
+++ b/framework/tests/test-data/dumpStorageEntityAdded.json
@@ -7,8 +7,6 @@
         ],
         "EntityName": "_System",
         "Error_Messages": null,
-        "LoggedComponents": {
-        },
         "ModulesPaused": false,
         "Session": "session",
         "SessionsAvailable": [

--- a/framework/tests/test-data/dumpStorageEntityComponentAdd.json
+++ b/framework/tests/test-data/dumpStorageEntityComponentAdd.json
@@ -7,8 +7,6 @@
         ],
         "EntityName": "_System",
         "Error_Messages": null,
-        "LoggedComponents": {
-        },
         "ModulesPaused": false,
         "Session": "session",
         "SessionsAvailable": [

--- a/framework/tests/test-data/dumpStorageInitial.json
+++ b/framework/tests/test-data/dumpStorageInitial.json
@@ -6,8 +6,6 @@
         ],
         "EntityName": "_System",
         "Error_Messages": null,
-        "LoggedComponents": {
-        },
         "ModulesPaused": false,
         "Session": "session",
         "SessionsAvailable": [

--- a/server-libs/modman-base/lib/systemmoduleeventsystem.cpp
+++ b/server-libs/modman-base/lib/systemmoduleeventsystem.cpp
@@ -13,7 +13,6 @@ static const char *entitiesComponentName =             "Entities";
 static const char *sessionComponentName =              "Session";
 static const char *sessionsAvailableComponentName =    "SessionsAvailable";
 static const char *notificationMessagesComponentName = "Error_Messages";
-static const char *loggedComponentsComponentName =     "LoggedComponents";
 static const char *modulesPausedComponentName =        "ModulesPaused";
 static const char *devModeComponentName =              "DevMode";
 
@@ -77,8 +76,6 @@ void SystemModuleEventSystem::processEvent(QEvent *t_event)
                         handleNotificationMessage(cData->newValue().toJsonObject());
                         t_event->accept();
                     }
-                    else if(cData->componentName() == loggedComponentsComponentName)
-                        validated = true;
                     else if(cData->componentName() == modulesPausedComponentName) {
                         validated = true;
                         setModulesPaused(cData->newValue().toBool());
@@ -176,7 +173,6 @@ void SystemModuleEventSystem::initOnce()
         componentData.insert(sessionComponentName, QVariant(m_currentSession));
         componentData.insert(sessionsAvailableComponentName, QVariant(m_availableSessions));
         componentData.insert(notificationMessagesComponentName, QVariant(m_notificationMessages.toJson()));
-        componentData.insert(loggedComponentsComponentName, QVariantMap());
         componentData.insert(modulesPausedComponentName, QVariant(false));
         componentData.insert(devModeComponentName, QVariant(false));
 

--- a/server-libs/modman-base/tests/test_modman_start.cpp
+++ b/server-libs/modman-base/tests/test_modman_start.cpp
@@ -30,7 +30,6 @@ void test_modman_start::emptyModman()
     QCOMPARE(VfTestComponentSpyFilter::first(systemComponents, "Entities").newValue, QVariant()); // _SYSTEM listed once SystemModuleEventSystem::initializeEntity is called
     QVERIFY(VfTestComponentSpyFilter::hasOne(systemComponents, "ModulesPaused"));
     QVERIFY(VfTestComponentSpyFilter::hasOne(systemComponents, "Error_Messages"));
-    QVERIFY(VfTestComponentSpyFilter::hasOne(systemComponents, "LoggedComponents"));
     QVERIFY(VfTestComponentSpyFilter::hasOne(systemComponents, "DevMode"));
 
     QCOMPARE(vfTestServer.getComponentChangeList().size(), 0);


### PR DESCRIPTION
…go to vf-logger

* This will cause monkey work
* We must do this now: All logger related regression tests contain system-module dumps which block us from painless changes. Make system-module independent of logger-module!