### PR TITLE
EventHandler::customEvent: Fix propagating accepted events

### DIFF
--- a/framework/vf-event/ve_eventhandler.cpp
+++ b/framework/vf-event/ve_eventhandler.cpp
@@ -72,13 +72,11 @@ void EventHandler::clearSubsystems()
 void EventHandler::customEvent(QEvent *event)
 {
     Q_ASSERT(event != nullptr);
-    for(int i=0; i < m_subsystems.count(); ++i) {
+    for(int i=0; i < m_subsystems.count() && event->isAccepted()==false; ++i) {
         EventSystem* eventSystem = m_subsystems.at(i);
         eventSystem->processEvent(event);
-        if(event->isAccepted()) {
+        if(event->isAccepted())
             emit sigEventAccepted(eventSystem, event);
-            break;
-        }
     }
 }
 


### PR DESCRIPTION
At the time the bug was introduced, we were not aware that there is ModuleEventHandler which can accept events before calling EventHandler::customEvent.

Bug introduced in:
commit b4e7f30e7b6c831ecf376cd4b655eaaf508de829
Author: Andreas Müller <schnitzeltony@gmail.com>
Date:   Sun Mar 31 20:09:30 2024 +0200

    ve_eventhandler: Add a signal eventAccepted