### PR TITLE
vs_clientstorageeventsystem: do not eat the event if already subscribed

### DIFF
--- a/framework/vf-storage/lib/vs_clientstorageeventsystem.cpp
+++ b/framework/vf-storage/lib/vs_clientstorageeventsystem.cpp
@@ -73,7 +73,7 @@ void ClientStorageEventSystem::processIntrospectionData(QEvent *event)
     EntityMap* entityMap = m_privHash->findEntity(entityId);
 
     if(entityMap)
-        ErrorDataSender::errorOut(QString("Cannot add entity, entity id already exists: %1").arg(iData->entityId()), event, this);
+        qWarning("Cannot add entity, entity id already exists: %i", iData->entityId());
     else {
         m_privHash->insertEntity(entityId);
         entityMap = m_privHash->findEntity(entityId);


### PR DESCRIPTION
If you have an entity already in your storage (previous subscribe), the current state will produce an error which leads to the event being accepted. 

Having this entity already in your store does not pose an error worth accepting/deleting the event. It does not hinder the storage from functioning correctly, but other eventhandlers maybe registered after the storage and are interested in the contents of this event. 

Conclusion: why accept the event, effectively breaking systems which may come after you and are dependant on this event, when this does not produce an error for the storage, it could just ignore it. 